### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Basic Noir anonymous proof of membership
 
 ## Requirements
 
-- Noir is based upon [Rust](https://www.rust-lang.org/tools/install), and we will need Noir's package manager `nargo` in order to compile our circuits. Further installation instructions can be found [here](https://noir-lang.github.io/book/getting_started/install.html).
+- Noir is based upon [Rust](https://www.rust-lang.org/tools/install), and we will need Noir's package manager `nargo` in order to compile our circuits. Further installation instructions can be found [here](https://noir-lang.org/getting_started/nargo_installation).
 - The typescript tests and contracts live within a hardhat project, where we use [yarn](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable) as the package manager.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Basic Noir anonymous proof of membership
 
 ## Requirements
 
-- Noir is based upon [Rust](https://www.rust-lang.org/tools/install), and we will need to Noir's package manager `nargo` in order to compile our circuits. Further installation instructions for can be found [here](https://noir-lang.github.io/book/getting_started/install.html).
+- Noir is based upon [Rust](https://www.rust-lang.org/tools/install), and we will need Noir's package manager `nargo` in order to compile our circuits. Further installation instructions can be found [here](https://noir-lang.github.io/book/getting_started/install.html).
 - The typescript tests and contracts live within a hardhat project, where we use [yarn](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable) as the package manager.
 
 ## Development


### PR DESCRIPTION
Fixed Grammatical Errors
Earlier link wasn't working, Changed it from a faulty one to the original link

Previous link -> https://noir-lang.github.io/book/getting_started/install.html
Current link -> https://noir-lang.org/getting_started/nargo_installation